### PR TITLE
Support `hamze` and `ayn` before `Long Vowels` in `toFenglish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This function takes a `Persian` text and returns its `Fenglish` text.
 **Notes:**
 
 -   Vowels are effective in the output of this function
--   _This function works correctly for "Alef", "Ayn", "Vaav" and "Ye" letters and not work correctly for other letters yet._ (**Work in progress...**)
+-   _This function works correctly for "Alef", "Ayn", "Hamza", "Vaav" and "Ye" letters and not work correctly for other letters yet._ (**Work in progress...**)
 
 #### Example
 

--- a/src/to-fenglish/__test__/letter-checker.test.ts
+++ b/src/to-fenglish/__test__/letter-checker.test.ts
@@ -1,6 +1,6 @@
 import { LetterChecker } from '../letter-checker'
 
-const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn } = LetterChecker
+const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn, isHamza } = LetterChecker
 
 describe('LetterChecker', () => {
 	describe('isShortVowel', () => {
@@ -108,6 +108,12 @@ describe('LetterChecker', () => {
 	describe('isAyn', () => {
 		it('Should identify `ayn`', () => {
 			expect(isAyn('ع')).toBeTruthy()
+		})
+	})
+
+	describe('isHamza', () => {
+		it('Should identify `hamza`', () => {
+			expect(isHamza('ئ')).toBeTruthy()
 		})
 	})
 

--- a/src/to-fenglish/__test__/letter-checker.test.ts
+++ b/src/to-fenglish/__test__/letter-checker.test.ts
@@ -1,6 +1,6 @@
 import { LetterChecker } from '../letter-checker'
 
-const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe } = LetterChecker
+const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn } = LetterChecker
 
 describe('LetterChecker', () => {
 	describe('isShortVowel', () => {
@@ -102,6 +102,12 @@ describe('LetterChecker', () => {
 
 		it('Should identify `a ba kolah` as `alef`', () => {
 			expect(isAlef('آ')).toBeTruthy()
+		})
+	})
+
+	describe('isAyn', () => {
+		it('Should identify `ayn`', () => {
+			expect(isAyn('ع')).toBeTruthy()
 		})
 	})
 

--- a/src/to-fenglish/__test__/to-fenglish.test.ts
+++ b/src/to-fenglish/__test__/to-fenglish.test.ts
@@ -94,7 +94,7 @@ describe('toFenglish', () => {
 			)
 		})
 
-		it('Word containing <... + AYN + LongVowel(YE and ALEF)> format should replace related short vowel instead of ayn', () => {
+		it('Word containing <... + AYN + LongVowel(YE, ALEF and VAAV)> format should use related short vowel instead of ayn', () => {
 			expectPersianIsFenglish(
 				['مُعادِل', 'راعی', 'مُعانِدین', 'سَعید', 'مُعین', 'مَسعود'],
 				['moaadel', 'raei', 'moaanedin', 'saeid', 'moein', 'masood'],
@@ -105,6 +105,15 @@ describe('toFenglish', () => {
 			expectPersianIsFenglish(
 				['مُعَلِم', 'عَلامَت', 'عِشق', 'عَمَل', 'عَذاب'],
 				['moalem', 'alamat', 'eshgh', 'amal', 'azab'],
+			)
+		})
+	})
+
+	describe('hamza', () => {
+		it('Word containing <HAMZA + LongVowel(YE, ALEF and VAAV)> format should use related short vowel instead of hamza', () => {
+			expectPersianIsFenglish(
+				['رَئوفی', 'کَدخُدائی', 'آئین', 'تِئاتر', 'رَئیس', 'زِئوس', 'کاکائو', 'رِئال', 'سورِئال'],
+				['raoofi', 'kadkhodaei', 'aein', 'teatr', 'raeis', 'zeoos', 'kakaoo', 'real', 'sooreal'],
 			)
 		})
 	})

--- a/src/to-fenglish/__test__/to-fenglish.test.ts
+++ b/src/to-fenglish/__test__/to-fenglish.test.ts
@@ -101,7 +101,7 @@ describe('toFenglish', () => {
 			)
 		})
 
-		it('Word containing <AYN + Vowel> format should remove ayn', () => {
+		it('Word containing <AYN + ShortVowel> format should remove ayn', () => {
 			expectPersianIsFenglish(
 				['مُعَلِم', 'عَلامَت', 'عِشق', 'عَمَل', 'عَذاب'],
 				['moalem', 'alamat', 'eshgh', 'amal', 'azab'],

--- a/src/to-fenglish/__test__/to-fenglish.test.ts
+++ b/src/to-fenglish/__test__/to-fenglish.test.ts
@@ -73,17 +73,38 @@ describe('toFenglish', () => {
 	})
 
 	describe('ayn', () => {
-		it('Word containing <AYN + Consonant> format should be `aynC`', () => {
+		it('Word containing <AYN + Consonant> format should remove ayn', () => {
 			expectPersianIsFenglish(
-				['اِعلانات', 'مِعرات', 'مُعادِل', 'عامِل'],
-				['elanat', 'merat', 'moadel', 'amel'],
+				['اِعلانات', 'مِعرات', 'مَعلوم', 'دَعوا', 'رَعشِه'],
+				['elanat', 'merat', 'maloom', 'dava', 'rasheh'],
 			)
 		})
 
-		it('Word containing <AYN + Vowel> format should be `aynV`', () => {
+		it('Word start with <AYN + ALEF> format should remove ayn', () => {
 			expectPersianIsFenglish(
-				['مُعَلِم', 'عَلامَت', 'عاشِق', 'عِشق', 'عَمَل', 'عَذاب'],
-				['moalem', 'alamat', 'ashegh', 'eshgh', 'amal', 'azab'],
+				['عامِل', 'عاشِق', 'عادی'],
+				['amel', 'ashegh', 'adi'],
+			)
+		})
+
+		it('Word containing <AYN + Vowel> format should remove ayn', () => {
+			expectPersianIsFenglish(
+				['مُعَلِم', 'مُعَدِل', 'عَلامَت', 'عِشق', 'عَمَل', 'عَذاب'],
+				['moalem', 'moadel', 'alamat', 'eshgh', 'amal', 'azab'],
+			)
+		})
+
+		it('Word containing <... + AYN + LongVowel(YE and ALEF)> format should replace related short vowel instead of ayn', () => {
+			expectPersianIsFenglish(
+				['مُعادِل', 'راعی', 'مُعانِدین', 'سَعید', 'مُعین', 'مَسعود'],
+				['moaadel', 'raei', 'moaanedin', 'saeid', 'moein', 'masood'],
+			)
+		})
+
+		it('Word containing <AYN + Vowel> format should remove ayn', () => {
+			expectPersianIsFenglish(
+				['مُعَلِم', 'عَلامَت', 'عِشق', 'عَمَل', 'عَذاب'],
+				['moalem', 'alamat', 'eshgh', 'amal', 'azab'],
 			)
 		})
 	})

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -2,7 +2,7 @@ import lettersMap from './assets/letters-map'
 import { LetterChecker } from './letter-checker'
 import { Syllables } from './syllables'
 
-const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isAyn, isVaav, isKhaa, isYe } = LetterChecker
+const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isAyn, isVaav, isKhaa, isYe, isHamza } = LetterChecker
 
 export class ToFenglish {
 	private text: string
@@ -55,6 +55,11 @@ export class ToFenglish {
 				continue
 			}
 
+			if(isHamza(this.current)) {
+				this.onCurrentLetterIsHamza()
+				continue
+			}
+
 			if(isVaav(this.current) && this.position !== 1) {
 				this.onCurrentLetterIsVaav()
 				continue
@@ -101,6 +106,12 @@ export class ToFenglish {
 				this.fenglish += 'e'
 				return
 			}
+		}
+	}
+
+	private onCurrentLetterIsHamza() {
+		if(isLongVowel(this.next) && isYe(this.next)) {
+			this.fenglish += 'e'
 		}
 	}
 

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -24,7 +24,7 @@ export class ToFenglish {
 
 		for (const word of words) {
 			// if word's format is <ALEF (may exists) + LETTER + ALEF + LETTER>
-			if(/^(آ|ا)?.(آ|ا).$/.test(word)) {
+			if(/^([آا]?).([آا]).$/.test(word)) {
 				this.onWordShouldHaveTwoA(word)
 			} else {
 				this.fenglish = ''
@@ -96,7 +96,7 @@ export class ToFenglish {
 	}
 
 	private onCurrentLetterIsAyn() {
-		if(this.positionInWord > 1 && isLongVowel(this.next)) {
+		if(this.positionInWord > 1) {
 			if(isAlef(this.next)) {
 				this.fenglish += 'a'
 				return
@@ -110,7 +110,7 @@ export class ToFenglish {
 	}
 
 	private onCurrentLetterIsHamza() {
-		if(isLongVowel(this.next) && isYe(this.next)) {
+		if(isYe(this.next)) {
 			this.fenglish += 'e'
 		}
 	}

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -2,11 +2,12 @@ import lettersMap from './assets/letters-map'
 import { LetterChecker } from './letter-checker'
 import { Syllables } from './syllables'
 
-const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isVaav, isKhaa, isYe } = LetterChecker
+const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isAyn, isVaav, isKhaa, isYe } = LetterChecker
 
 export class ToFenglish {
 	private text: string
 	private position = 1
+	private positionInWord = 0
 	private fenglish = ''
 	private previous = ''
 	private current = ''
@@ -23,7 +24,7 @@ export class ToFenglish {
 
 		for (const word of words) {
 			// if word's format is <ALEF (may exists) + LETTER + ALEF + LETTER>
-			if(/^(آ|ا){0,1}.(آ|ا).$/.test(word)) {
+			if(/^(آ|ا)?.(آ|ا).$/.test(word)) {
 				this.onWordShouldHaveTwoA(word)
 			} else {
 				this.fenglish = ''
@@ -39,13 +40,18 @@ export class ToFenglish {
 	}
 
 	private bySyllable() {
-		for (this.position = 1; this.position <= this.syllable.length; this.position++) {
+		for (this.position = 1; this.position <= this.syllable.length; this.position++, this.positionInWord++) {
 			this.previous = this.syllable[this.position - 2]
 			this.current = this.syllable[this.position - 1]
 			this.next = this.syllable[this.position]
 
 			if(isAlef(this.current)) {
 				this.onCurrentLetterIsAlef()
+				continue
+			}
+
+			if(isAyn(this.current)) {
+				this.onCurrentLetterIsAyn()
 				continue
 			}
 
@@ -82,6 +88,20 @@ export class ToFenglish {
 		}
 
 		this.translateCurrentLetter()
+	}
+
+	private onCurrentLetterIsAyn() {
+		if(this.positionInWord > 1 && isLongVowel(this.next)) {
+			if(isAlef(this.next)) {
+				this.fenglish += 'a'
+				return
+			}
+
+			if(isYe(this.next)) {
+				this.fenglish += 'e'
+				return
+			}
+		}
 	}
 
 	private onCurrentLetterIsVaav() {

--- a/src/to-fenglish/letter-checker.ts
+++ b/src/to-fenglish/letter-checker.ts
@@ -26,6 +26,10 @@ export class LetterChecker {
 		return ['آ', 'ا'].includes(char)
 	}
 
+	public static isAyn(char: string) {
+		return 'ع' == char
+	}
+
 	public static isVaav(char: string) {
 		return char == 'و'
 	}

--- a/src/to-fenglish/letter-checker.ts
+++ b/src/to-fenglish/letter-checker.ts
@@ -30,6 +30,10 @@ export class LetterChecker {
 		return 'ع' == char
 	}
 
+	public static isHamza(char: string) {
+		return 'ئ' == char
+	}
+
 	public static isVaav(char: string) {
 		return char == 'و'
 	}


### PR DESCRIPTION
- Add the `isAyn` method to `LetterChecker`
- Use a related short vowel instead of the long vowel that is placed after `ayn`
- Add the `isHamza` method to `LetterChecker`
- Use a related short vowel instead of the long vowel that is placed after `hamza`