### PR TITLE
Remove `heh` when `toFenglish` detect <`E` + `H`> format at ending of the word

### DIFF
--- a/src/to-fenglish/__test__/letter-checker.test.ts
+++ b/src/to-fenglish/__test__/letter-checker.test.ts
@@ -1,6 +1,6 @@
 import { LetterChecker } from '../letter-checker'
 
-const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn, isHamza } = LetterChecker
+const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn, isHamza, isE, isH } = LetterChecker
 
 describe('LetterChecker', () => {
 	describe('isShortVowel', () => {
@@ -89,6 +89,12 @@ describe('LetterChecker', () => {
 		})
 	})
 
+	describe('isE', () => {
+		it('Should identify `e`', () => {
+			expect(isE('ِ')).toBeTruthy()
+		})
+	})
+
 	describe('isO', () => {
 		it('Should identify `o`', () => {
 			expect(isO('ُ')).toBeTruthy()
@@ -132,6 +138,12 @@ describe('LetterChecker', () => {
 	describe('isYe', () => {
 		it('Should identify `ye`', () => {
 			expect(isYe('ی')).toBeTruthy()
+		})
+	})
+
+	describe('isH', () => {
+		it('Should identify `heh`', () => {
+			expect(isH('ه')).toBeTruthy()
 		})
 	})
 

--- a/src/to-fenglish/__test__/to-fenglish.test.ts
+++ b/src/to-fenglish/__test__/to-fenglish.test.ts
@@ -76,7 +76,7 @@ describe('toFenglish', () => {
 		it('Word containing <AYN + Consonant> format should remove ayn', () => {
 			expectPersianIsFenglish(
 				['اِعلانات', 'مِعرات', 'مَعلوم', 'دَعوا', 'رَعشِه'],
-				['elanat', 'merat', 'maloom', 'dava', 'rasheh'],
+				['elanat', 'merat', 'maloom', 'dava', 'rashe'],
 			)
 		})
 
@@ -209,6 +209,15 @@ describe('toFenglish', () => {
 			expectPersianIsFenglish(
 				['بیا', 'ریا', 'میام', 'شیار', 'خیار', 'نِمیام', 'سیاه'],
 				['biya', 'riya', 'miyam', 'shiyar', 'khiyar', 'nemiyam', 'siyah'],
+			)
+		})
+	})
+
+	describe('eh', () => {
+		it('Word end with <E + H> format should remove `H`', () => {
+			expectPersianIsFenglish(
+				['یوسُفیِه', 'مَجیدیِه', 'قُسطَنتَنیِه', 'یِکیِه'],
+				['yoosofiye', 'majidiye', 'ghostantaniye', 'yekiye'],
 			)
 		})
 	})

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -2,7 +2,7 @@ import lettersMap from './assets/letters-map'
 import { LetterChecker } from './letter-checker'
 import { Syllables } from './syllables'
 
-const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isAyn, isVaav, isKhaa, isYe, isHamza } = LetterChecker
+const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isAyn, isVaav, isKhaa, isYe, isHamza, isE, isH } = LetterChecker
 
 export class ToFenglish {
 	private text: string
@@ -12,6 +12,7 @@ export class ToFenglish {
 	private previous = ''
 	private current = ''
 	private next = ''
+	private word = ''
 	private syllable = ''
 
 	constructor(text: string|null|undefined) {
@@ -22,13 +23,13 @@ export class ToFenglish {
 		const words = this.text.split(' ')
 		const fenglishWords = []
 
-		for (const word of words) {
+		for (this.word of words) {
 			// if word's format is <ALEF (may exists) + LETTER + ALEF + LETTER>
-			if(/^([آا]?).([آا]).$/.test(word)) {
-				this.onWordShouldHaveTwoA(word)
+			if(/^([آا]?).([آا]).$/.test(this.word)) {
+				this.onWordShouldHaveTwoA(this.word)
 			} else {
 				this.fenglish = ''
-				for(this.syllable of new Syllables(word).split()) {
+				for(this.syllable of new Syllables(this.word).split()) {
 					this.bySyllable()
 				}
 			}
@@ -68,6 +69,10 @@ export class ToFenglish {
 			if(isYe(this.current)) {
 				this.onCurrentLetterIsYe()
 				continue
+			}
+
+			if(this.next == undefined && isE(this.previous) && isH(this.current)) {
+				break
 			}
 
 			this.translateCurrentLetter()

--- a/src/to-fenglish/letter-checker.ts
+++ b/src/to-fenglish/letter-checker.ts
@@ -18,6 +18,10 @@ export class LetterChecker {
 		return LetterChecker.isShortVowel(char) || LetterChecker.isLongVowel(char)
 	}
 
+	public static isE(char: string) {
+		return 'ِ' == char
+	}
+
 	public static isO(char: string) {
 		return 'ُ' == char
 	}
@@ -44,5 +48,9 @@ export class LetterChecker {
 
 	public static isYe(char: string) {
 		return char == 'ی'
+	}
+
+	public static isH(char: string) {
+		return char == 'ه'
 	}
 }


### PR DESCRIPTION
- When `toFenglish` detects the <`E` + `H`> format at the end of the word, remove `h`
- Add the `isE` method to `LetterChecker`
- Add the `isH` method to `LetterChecker`