### PR TITLE
Add apostrophe after `VOWEL` in <`VOWEL` + `AYN` + `RelatedVowel`> format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://www.npmjs.com/package/fenglish"><img src="https://img.shields.io/npm/v/fenglish?label=version" alt="Version"></a>
 <a href="https://www.npmjs.com/package/fenglish?minimal=true"><img src="https://img.shields.io/npm/dm/fenglish" alt="Downloads"></a>
-<img src="https://img.shields.io/github/workflow/status/kadsin/fenglish/Test?label=tests" alt="Tests">
+<img src="https://img.shields.io/github/actions/workflow/status/kadsin/fenglish/test-project.yml?label=tests" alt="Tests">
 <img src="https://img.shields.io/github/license/kadsin/fenglish" alt="License">
 
 Includes utilities which play with persian texts for Fenglish purposes.

--- a/src/to-fenglish/__test__/letter-checker.test.ts
+++ b/src/to-fenglish/__test__/letter-checker.test.ts
@@ -1,6 +1,15 @@
 import { LetterChecker } from '../letter-checker'
 
-const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn, isHamza, isE, isH } = LetterChecker
+const { isConsonant, isShortVowel, isLongVowel, isVowel, isAlef, isO, isKhaa, isVaav, isYe, isAyn,
+	isHamza, isE, isH, isRelatedVowels } = LetterChecker
+
+const VOWEL_A_SHORT = 'َ'
+const VOWEL_E_SHORT = 'ِ'
+const VOWEL_O_SHORT = 'ُ'
+
+const ALEF = 'ا'
+const YE = 'ی'
+const VAAV = 'و'
 
 describe('LetterChecker', () => {
 	describe('isShortVowel', () => {
@@ -17,15 +26,15 @@ describe('LetterChecker', () => {
 		})
 
 		it('Should identify `a` as a `vowel`', () => {
-			expect(isShortVowel('َ')).toBeTruthy()
+			expect(isShortVowel(VOWEL_A_SHORT)).toBeTruthy()
 		})
 
 		it('Should identify `e` as a `vowel`', () => {
-			expect(isShortVowel('ِ')).toBeTruthy()
+			expect(isShortVowel(VOWEL_E_SHORT)).toBeTruthy()
 		})
 
 		it('Should identify `o` as a `vowel`', () => {
-			expect(isShortVowel('ُ')).toBeTruthy()
+			expect(isShortVowel(VOWEL_O_SHORT)).toBeTruthy()
 		})
 	})
 
@@ -35,7 +44,7 @@ describe('LetterChecker', () => {
 		})
 
 		it('Should identify `alef` as a `vowel`', () => {
-			expect(isLongVowel('ا')).toBeTruthy()
+			expect(isLongVowel(ALEF)).toBeTruthy()
 		})
 
 		it('Should identify `hamze` as a `vowel`', () => {
@@ -43,7 +52,7 @@ describe('LetterChecker', () => {
 		})
 
 		it('Should identify `ی` as a `vowel`', () => {
-			expect(isLongVowel('ی')).toBeTruthy()
+			expect(isLongVowel(YE)).toBeTruthy()
 		})
 	})
 
@@ -61,15 +70,15 @@ describe('LetterChecker', () => {
 		})
 
 		it('Should identify `a` as a `vowel`', () => {
-			expect(isVowel('َ')).toBeTruthy()
+			expect(isVowel(VOWEL_A_SHORT)).toBeTruthy()
 		})
 
 		it('Should identify `e` as a `vowel`', () => {
-			expect(isVowel('ِ')).toBeTruthy()
+			expect(isVowel(VOWEL_E_SHORT)).toBeTruthy()
 		})
 
 		it('Should identify `o` as a `vowel`', () => {
-			expect(isVowel('ُ')).toBeTruthy()
+			expect(isVowel(VOWEL_O_SHORT)).toBeTruthy()
 		})
 
 		it('Should identify `alef ba kolah` as a `vowel`', () => {
@@ -77,7 +86,7 @@ describe('LetterChecker', () => {
 		})
 
 		it('Should identify `alef` as a `vowel`', () => {
-			expect(isVowel('ا')).toBeTruthy()
+			expect(isVowel(ALEF)).toBeTruthy()
 		})
 
 		it('Should identify `hamze` as a `vowel`', () => {
@@ -85,25 +94,25 @@ describe('LetterChecker', () => {
 		})
 
 		it('Should identify `ی` as a `vowel`', () => {
-			expect(isVowel('ی')).toBeTruthy()
+			expect(isVowel(YE)).toBeTruthy()
 		})
 	})
 
 	describe('isE', () => {
 		it('Should identify `e`', () => {
-			expect(isE('ِ')).toBeTruthy()
+			expect(isE(VOWEL_E_SHORT)).toBeTruthy()
 		})
 	})
 
 	describe('isO', () => {
 		it('Should identify `o`', () => {
-			expect(isO('ُ')).toBeTruthy()
+			expect(isO(VOWEL_O_SHORT)).toBeTruthy()
 		})
 	})
 
 	describe('isAlef', () => {
 		it('Should identify `a` as `alef`', () => {
-			expect(isAlef('ا')).toBeTruthy()
+			expect(isAlef(ALEF)).toBeTruthy()
 		})
 
 		it('Should identify `a ba kolah` as `alef`', () => {
@@ -125,7 +134,7 @@ describe('LetterChecker', () => {
 
 	describe('isVaav', () => {
 		it('Should identify `vaav`', () => {
-			expect(isVaav('و')).toBeTruthy()
+			expect(isVaav(VAAV)).toBeTruthy()
 		})
 	})
 
@@ -137,7 +146,7 @@ describe('LetterChecker', () => {
 
 	describe('isYe', () => {
 		it('Should identify `ye`', () => {
-			expect(isYe('ی')).toBeTruthy()
+			expect(isYe(YE)).toBeTruthy()
 		})
 	})
 
@@ -151,6 +160,47 @@ describe('LetterChecker', () => {
 		it('Should not identify short vowels as consonant', () => {
 			const vowels = 'ًٌٍَُِ'.split('')
 			vowels.forEach((v) => expect(isConsonant(v)).toBeFalsy())
+		})
+	})
+
+	describe('isRelatedVowels', () => {
+		it('Should identify `a` (short) and `a` (long) related', () => {
+			expect(isRelatedVowels(VOWEL_A_SHORT, ALEF)).toBeTruthy()
+			expect(isRelatedVowels(ALEF, VOWEL_A_SHORT)).toBeTruthy()
+		})
+
+		it('Should identify `a` (short) with it self as related', () => {
+			expect(isRelatedVowels(VOWEL_A_SHORT, VOWEL_A_SHORT)).toBeTruthy()
+		})
+
+		it('Should identify `a` (long) with it self as related', () => {
+			expect(isRelatedVowels(ALEF, ALEF)).toBeTruthy()
+		})
+
+		it('Should identify `e` (short) and `e` (long) related', () => {
+			expect(isRelatedVowels(VOWEL_E_SHORT, YE)).toBeTruthy()
+			expect(isRelatedVowels(YE, VOWEL_E_SHORT)).toBeTruthy()
+		})
+
+		it('Should identify `e` (short) with it self as related', () => {
+			expect(isRelatedVowels(VOWEL_E_SHORT, VOWEL_E_SHORT)).toBeTruthy()
+		})
+
+		it('Should identify `e` (long) with it self as related', () => {
+			expect(isRelatedVowels(YE, YE)).toBeTruthy()
+		})
+
+		it('Should identify `o` and `oo` (long) related', () => {
+			expect(isRelatedVowels(VOWEL_O_SHORT, VAAV)).toBeTruthy()
+			expect(isRelatedVowels(VAAV, VOWEL_O_SHORT)).toBeTruthy()
+		})
+
+		it('Should identify `o` with it self as related', () => {
+			expect(isRelatedVowels(VOWEL_O_SHORT, VOWEL_O_SHORT)).toBeTruthy()
+		})
+
+		it('Should identify `oo` (long) with it self as related', () => {
+			expect(isRelatedVowels(VAAV, VAAV)).toBeTruthy()
 		})
 	})
 })

--- a/src/to-fenglish/__test__/to-fenglish.test.ts
+++ b/src/to-fenglish/__test__/to-fenglish.test.ts
@@ -221,6 +221,15 @@ describe('toFenglish', () => {
 			)
 		})
 	})
+
+	describe('pause', () => {
+		it('Add apostrophe after `Vowel` in word contains <Vowel + AYN + RelatedVowel> format', () => {
+			expectPersianIsFenglish(
+				['فِعیل', 'مَعانی', 'مُوعود', 'تَعَدی', 'شایِعِه', 'تَعَهُد'],
+				['fe\'eil', 'ma\'aani', 'mo\'ood', 'ta\'adi', 'shaye\'eh', 'ta\'ahod'],
+			)
+		})
+	})
 })
 
 function expectPersianIsFenglish(persian: Array<string|null|undefined>, fenglish: string[]) {

--- a/src/to-fenglish/__test__/to-fenglish.test.ts
+++ b/src/to-fenglish/__test__/to-fenglish.test.ts
@@ -225,8 +225,8 @@ describe('toFenglish', () => {
 	describe('pause', () => {
 		it('Add apostrophe after `Vowel` in word contains <Vowel + AYN + RelatedVowel> format', () => {
 			expectPersianIsFenglish(
-				['فِعیل', 'مَعانی', 'مُوعود', 'تَعَدی', 'شایِعِه', 'تَعَهُد'],
-				['fe\'eil', 'ma\'aani', 'mo\'ood', 'ta\'adi', 'shaye\'eh', 'ta\'ahod'],
+				['فِعیل', 'مَعانی', 'مُوعود', 'تَعَدی', 'شایِعِه', 'تَعَهُد', 'مُراعات'],
+				['fe\'eil', 'ma\'aani', 'mo\'ood', 'ta\'adi', 'shaye\'e', 'ta\'ahod', 'mora\'aat'],
 			)
 		})
 	})

--- a/src/to-fenglish/assets/letters-map.ts
+++ b/src/to-fenglish/assets/letters-map.ts
@@ -1,4 +1,0 @@
-import { HashMap } from '../contracts/hash-map.interface'
-import lettersMap from './letters-map.json'
-
-export default <HashMap>lettersMap

--- a/src/to-fenglish/assets/letters-map.ts
+++ b/src/to-fenglish/assets/letters-map.ts
@@ -1,7 +1,4 @@
+import { HashMap } from '../contracts/hash-map.interface'
 import lettersMap from './letters-map.json'
 
-interface LettersMap {
-	[index: string]: string
-}
-
-export default <LettersMap>lettersMap
+export default <HashMap>lettersMap

--- a/src/to-fenglish/contracts/hash-map.interface.ts
+++ b/src/to-fenglish/contracts/hash-map.interface.ts
@@ -1,3 +1,0 @@
-export interface HashMap {
-	[index: string]: string
-}

--- a/src/to-fenglish/contracts/hash-map.interface.ts
+++ b/src/to-fenglish/contracts/hash-map.interface.ts
@@ -1,0 +1,3 @@
+export interface HashMap {
+	[index: string]: string
+}

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -1,4 +1,4 @@
-import lettersMap from './assets/letters-map'
+import lettersMap from './assets/letters-map.json'
 import { LetterChecker } from './letter-checker'
 import { Syllables } from './syllables'
 
@@ -181,7 +181,6 @@ export class ToFenglish {
 	}
 
 	private fenglishLetter(letter: string) {
-		const translated = lettersMap[letter]
-		return translated == undefined ? letter : translated
+		return (<{ [index :string] :string }> lettersMap)[letter] || letter
 	}
 }

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -2,7 +2,8 @@ import lettersMap from './assets/letters-map'
 import { LetterChecker } from './letter-checker'
 import { Syllables } from './syllables'
 
-const { isLongVowel, isShortVowel, isConsonant, isVowel, isO, isAlef, isAyn, isVaav, isKhaa, isYe, isHamza, isE, isH } = LetterChecker
+const { isLongVowel, isShortVowel, isRelatedVowels, isVowel, isO, isE,
+	isConsonant, isAlef, isAyn, isVaav, isKhaa, isYe, isHamza, isH } = LetterChecker
 
 export class ToFenglish {
 	private text: string
@@ -106,6 +107,13 @@ export class ToFenglish {
 
 	private onCurrentLetterIsAyn() {
 		if(this.positionInWord > 1) {
+			if(isRelatedVowels(
+				this.word[this.positionInWord - 1],
+				this.word[this.positionInWord + 1],
+			)) {
+				this.fenglish += '\''
+			}
+
 			if(isAlef(this.next)) {
 				this.fenglish += 'a'
 				return

--- a/src/to-fenglish/index.ts
+++ b/src/to-fenglish/index.ts
@@ -24,20 +24,24 @@ export class ToFenglish {
 		const fenglishWords = []
 
 		for (this.word of words) {
-			// if word's format is <ALEF (may exists) + LETTER + ALEF + LETTER>
-			if(/^([آا]?).([آا]).$/.test(this.word)) {
-				this.onWordShouldHaveTwoA(this.word)
-			} else {
-				this.fenglish = ''
-				for(this.syllable of new Syllables(this.word).split()) {
-					this.bySyllable()
-				}
-			}
-
+			this.byWord()
 			fenglishWords.push(this.fenglish)
 		}
 
 		return fenglishWords.join(' ')
+	}
+
+	private byWord() {
+		// if word's format is <ALEF (may exists) + LETTER + ALEF + LETTER>
+		if(/^([آا]?).([آا]).$/.test(this.word)) {
+			this.onWordShouldHaveTwoA(this.word)
+			return
+		}
+
+		this.fenglish = ''
+		for(this.syllable of new Syllables(this.word).split()) {
+			this.bySyllable()
+		}
 	}
 
 	private bySyllable() {

--- a/src/to-fenglish/letter-checker.ts
+++ b/src/to-fenglish/letter-checker.ts
@@ -1,5 +1,3 @@
-import { HashMap } from './contracts/hash-map.interface'
-
 export class LetterChecker {
 	/**
 	 * @summary is it one of `an`, `en`, `on`, `a`, `e`, `o`?
@@ -21,7 +19,7 @@ export class LetterChecker {
 	}
 
 	public static isRelatedVowels(first: string, second: string) {
-		const voice: HashMap = {
+		const voice: { [index :string] :string } = {
 			'ا': 'a',
 			'َ': 'a', // __َ_
 			'ِ': 'e', // ‾‾ِ‾

--- a/src/to-fenglish/letter-checker.ts
+++ b/src/to-fenglish/letter-checker.ts
@@ -1,3 +1,5 @@
+import { HashMap } from './contracts/hash-map.interface'
+
 export class LetterChecker {
 	/**
 	 * @summary is it one of `an`, `en`, `on`, `a`, `e`, `o`?
@@ -16,6 +18,19 @@ export class LetterChecker {
 
 	public static isVowel(char: string) {
 		return LetterChecker.isShortVowel(char) || LetterChecker.isLongVowel(char)
+	}
+
+	public static isRelatedVowels(first: string, second: string) {
+		const voice: HashMap = {
+			'ا': 'a',
+			'َ': 'a', // __َ_
+			'ِ': 'e', // ‾‾ِ‾
+			'ی': 'e',
+			'ُ': 'o', // __ُ_
+			'و': 'o',
+		}
+
+		return voice[first] === voice[second]
 	}
 
 	public static isE(char: string) {


### PR DESCRIPTION
- Add `isRelatedVowels` to `LetterChecker`
- Add apostrophe after `VOWEL` in <`VOWEL` + `AYN` + `RelatedVowel`> format